### PR TITLE
Implemented setTextSize(...) and setTextColor(...) functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+
+**This fork contains some extra functionality, the ability to programatically update text color and size during app runtime.
+Get it [here, on jitpack](https://jitpack.io/#Lissy93/DxLoadingButton/programmatically-set-button-text-styles-SNAPSHOT).**
+
+With thanks to [@StevenDXC](https://github.com/StevenDXC) for the origional, which is [here](https://github.com/StevenDXC/DxLoadingButton) 🙌.
+
+
 # DxLoadingButton
 
 android button to loading view with animation,and load successful/failed animation

--- a/library/src/main/java/com/dx/dxloadingbutton/lib/LoadingButton.java
+++ b/library/src/main/java/com/dx/dxloadingbutton/lib/LoadingButton.java
@@ -343,6 +343,16 @@ public class LoadingButton extends View {
         invalidate();
     }
 
+    public void setTextSize(int size){
+        mTextPaint.setTextSize(size*mDensity);
+        mTextWidth = mTextPaint.measureText(mText);
+        invalidate();
+    }
+
+    public void setTextColor(int color){
+        mTextPaint.setColor(color);
+        invalidate();
+    }
 
     public void setResetAfterFailed(boolean resetAfterFailed){
         this.resetAfterFailed = resetAfterFailed;


### PR DESCRIPTION
Seems a common requirement that some developers may need to programatically modify either the size or the color of the text within the awesome DxLoadingButton.

To use, just call : 
`mLoadingBtn.setTextSize(26); // To set size to 26dp` 
`mLoadingBtn.setTextColor(Color.RED); // To set the color of the text within the loading button`